### PR TITLE
Fix bug in createMapping

### DIFF
--- a/test/api.flux-test.ts
+++ b/test/api.flux-test.ts
@@ -42,7 +42,7 @@ setupTest("NAT-UPNP/Client", (opts) => {
   });
 
   //opts.run("Get and clear Port Mappings", async () => {
-  opts.run("Display Port Mappings", async () => {
+  opts.run("Display Existing Port Mappings", async () => {
     const mappings = await getMapping();
     if (mappings.length == 0) return true;
     for (i=0;i<mappings.length;i++) {
@@ -69,7 +69,7 @@ setupTest("NAT-UPNP/Client", (opts) => {
     for (i=0;i<5;i++) {
       console.log("%d:Map Random port %d to Local Port %d", i+1, globalPort[i], localPort[i]);
       await client.createMapping({
-        public: globalPort[i],
+        public: {port:globalPort[i], host:""},
         private: localPort[i],
         ttl: 0
       });


### PR DESCRIPTION
In createMapping pass Host='' along with external port number was causing issues with some Ver 1.0 clients

unifi supports Ver 1.1

must call create mapping with {port:ExternaPort, host:''} we may be able to set host to a string like RPC Port or presearch (app name)