### PR TITLE
New features - gateway caching / bypass, bugfixes

### DIFF
--- a/build/src/index.d.ts
+++ b/build/src/index.d.ts
@@ -19,7 +19,7 @@ export default natupnp;
  * Please look up the protol documentation if you wanna do
  * lower level communication.
  */
-export declare type RawResponse = Partial<Record<string, {
+export type RawResponse = Partial<Record<string, {
     "@": {
         "xmlns:u": string;
     };

--- a/build/src/nat-upnp/client.d.ts
+++ b/build/src/nat-upnp/client.d.ts
@@ -3,17 +3,21 @@ import Device from "./device";
 export declare class Client implements IClient {
     private readonly timeout;
     private readonly ssdp;
-    private gatewayInfo;
+    private readonly localAddress;
+    private readonly cacheGateway;
+    private upnpInfo;
     url: string | null;
     constructor(options?: {
         timeout?: number;
         url?: string;
+        localAddress?: string;
+        cacheGateway?: boolean;
     });
     createMapping(options: NewPortMappingOpts): Promise<RawResponse>;
     removeMapping(options: DeletePortMappingOpts): Promise<RawResponse>;
     getMappings(options?: GetMappingOpts): Promise<Mapping[]>;
     getPublicIp(): Promise<string>;
-    getGateway(): Promise<gatewayInfo>;
+    getGateway(): Promise<upnpInfo>;
     close(): void;
 }
 export default Client;
@@ -55,9 +59,9 @@ export interface GetMappingOpts {
     local?: boolean;
     description?: RegExp | string;
 }
-export interface gatewayInfo {
+export interface upnpInfo {
     gateway: Device;
-    address: string;
+    localAddress: string;
 }
 /**
  * Main client interface.
@@ -89,7 +93,7 @@ export interface IClient {
     /**
      * Get the gateway device for communication
      */
-    getGateway(): Promise<gatewayInfo>;
+    getGateway(): Promise<upnpInfo>;
     /**
      * Close the underlaying sockets and resources
      */

--- a/build/src/nat-upnp/client.d.ts
+++ b/build/src/nat-upnp/client.d.ts
@@ -1,20 +1,19 @@
 import { RawResponse } from "../index";
 import Device from "./device";
-import Ssdp from "./ssdp";
 export declare class Client implements IClient {
-    readonly timeout: number;
-    readonly ssdp: Ssdp;
+    private readonly timeout;
+    private readonly ssdp;
+    private gatewayInfo;
+    url: string | null;
     constructor(options?: {
         timeout?: number;
+        url?: string;
     });
     createMapping(options: NewPortMappingOpts): Promise<RawResponse>;
     removeMapping(options: DeletePortMappingOpts): Promise<RawResponse>;
     getMappings(options?: GetMappingOpts): Promise<Mapping[]>;
     getPublicIp(): Promise<string>;
-    getGateway(): Promise<{
-        gateway: Device;
-        address: string;
-    }>;
+    getGateway(): Promise<gatewayInfo>;
     close(): void;
 }
 export default Client;
@@ -51,15 +50,23 @@ export interface NewPortMappingOpts extends StandardOpts {
     description?: string;
     ttl?: number;
 }
-export declare type DeletePortMappingOpts = StandardOpts;
+export type DeletePortMappingOpts = StandardOpts;
 export interface GetMappingOpts {
     local?: boolean;
     description?: RegExp | string;
+}
+export interface gatewayInfo {
+    gateway: Device;
+    address: string;
 }
 /**
  * Main client interface.
  */
 export interface IClient {
+    /**
+     * Allows bypass of SSDP in situations with multicast issues
+    */
+    url: string | null;
     /**
      * Create a new port mapping
      * @param options Options for the new port mapping
@@ -82,10 +89,7 @@ export interface IClient {
     /**
      * Get the gateway device for communication
      */
-    getGateway(): Promise<{
-        gateway: Device;
-        address: string;
-    }>;
+    getGateway(): Promise<gatewayInfo>;
     /**
      * Close the underlaying sockets and resources
      */

--- a/build/src/nat-upnp/client.js
+++ b/build/src/nat-upnp/client.js
@@ -18,7 +18,9 @@ const ssdp_1 = __importDefault(require("./ssdp"));
 class Client {
     constructor(options = {}) {
         this.ssdp = new ssdp_1.default();
+        this.gatewayInfo = null;
         this.timeout = options.timeout || 1800;
+        this.url = options.url || null;
     }
     createMapping(options) {
         return __awaiter(this, void 0, void 0, function* () {
@@ -70,7 +72,8 @@ class Client {
                 const data = (yield gateway
                     .run("GetGenericPortMappingEntry", [["NewPortMappingIndex", i++]])
                     .catch((err) => {
-                    if (i !== 1) {
+                    var _a;
+                    if (i !== 1 || /ArrayIndexInvalid/.test((_a = err === null || err === void 0 ? void 0 : err.response) === null || _a === void 0 ? void 0 : _a.data)) {
                         end = true;
                     }
                 }));
@@ -132,6 +135,14 @@ class Client {
     }
     getGateway() {
         return __awaiter(this, void 0, void 0, function* () {
+            if (this.url) {
+                if (!this.gatewayInfo) {
+                    const address = new URL(this.url).hostname;
+                    this.gatewayInfo = { gateway: new device_1.default(this.url), address };
+                }
+                // resolve immediately without running SSDP.
+                return Promise.resolve(this.gatewayInfo);
+            }
             let timeouted = false;
             const p = this.ssdp.search("urn:schemas-upnp-org:device:InternetGatewayDevice:1");
             return new Promise((s, r) => {

--- a/build/src/nat-upnp/device.js
+++ b/build/src/nat-upnp/device.js
@@ -30,7 +30,7 @@ class Device {
             return axios_1.default
                 .get(url)
                 .then(({ data }) => new fast_xml_parser_1.XMLParser().parse(data))
-                .catch(() => new Error("Failed to lookup device description"));
+                .catch(() => { throw new Error("Router error. Failed to lookup device description"); });
         });
     }
     getService(types) {

--- a/build/src/nat-upnp/ssdp.d.ts
+++ b/build/src/nat-upnp/ssdp.d.ts
@@ -20,12 +20,12 @@ export declare class Ssdp implements ISsdp {
     close(): void;
 }
 export default Ssdp;
-declare type SearchArgs = [Record<string, string>, string];
-export declare type SearchCallback = (...args: SearchArgs) => void;
-declare type SearchEvent = <E extends Events>(ev: E, ...args: E extends "device" ? SearchArgs : []) => boolean;
-declare type Events = "device" | "end";
-declare type Event<E extends Events> = E extends "device" ? SearchCallback : () => void;
-declare type EventListener<T> = <E extends Events>(ev: E, callback: Event<E>) => T;
+type SearchArgs = [Record<string, string>, string];
+export type SearchCallback = (...args: SearchArgs) => void;
+type SearchEvent = <E extends Events>(ev: E, ...args: E extends "device" ? SearchArgs : []) => boolean;
+type Events = "device" | "end";
+type Event<E extends Events> = E extends "device" ? SearchCallback : () => void;
+type EventListener<T> = <E extends Events>(ev: E, callback: Event<E>) => T;
 export interface SsdpEmitter extends EventEmitter {
     removeListener: EventListener<this>;
     addListener: EventListener<this>;

--- a/build/src/nat-upnp/ssdp.js
+++ b/build/src/nat-upnp/ssdp.js
@@ -28,12 +28,12 @@ class Ssdp {
     }
     createSocket(iface) {
         const socket = dgram_1.default.createSocket(iface.family === "IPv4" ? "udp4" : "udp6");
-        socket.on("message", (message) => {
+        socket.on("message", (message, remote) => {
             // Ignore messages after closing sockets
             if (this.closed)
                 return;
             // Parse response
-            this.parseResponse(message.toString(), socket.address);
+            this.parseResponse(message.toString(), remote.address);
         });
         // Bind in next tick (sockets should be me in this.sockets array)
         process.nextTick(() => {

--- a/build/src/nat-upnp/ssdp.js
+++ b/build/src/nat-upnp/ssdp.js
@@ -107,8 +107,19 @@ class Ssdp {
         return emitter;
     }
     close() {
-        this.sockets.forEach((socket) => socket.close());
-        this.closed = true;
+        // idempotent
+        if (!this.closed) {
+            try {
+                this.sockets.forEach((socket) => socket.close());
+            }
+            catch (_a) {
+                // pass
+            }
+            this.sockets.length = 0;
+            this.closed = true;
+            this.bound = false;
+            this.boundCount = 0;
+        }
     }
 }
 exports.Ssdp = Ssdp;

--- a/build/src/nat-upnp/ssdp.js
+++ b/build/src/nat-upnp/ssdp.js
@@ -28,12 +28,12 @@ class Ssdp {
     }
     createSocket(iface) {
         const socket = dgram_1.default.createSocket(iface.family === "IPv4" ? "udp4" : "udp6");
-        socket.on("message", (message, remote) => {
+        socket.on("message", (message) => {
             // Ignore messages after closing sockets
             if (this.closed)
                 return;
             // Parse response
-            this.parseResponse(message.toString(), remote.address);
+            this.parseResponse(message.toString(), socket.address().address);
         });
         // Bind in next tick (sockets should be me in this.sockets array)
         process.nextTick(() => {

--- a/build/src/nat-upnp/ssdp.js
+++ b/build/src/nat-upnp/ssdp.js
@@ -33,7 +33,7 @@ class Ssdp {
             if (this.closed)
                 return;
             // Parse response
-            this.parseResponse(message.toString(), socket.address().address);
+            this.parseResponse(message.toString(), socket.address);
         });
         // Bind in next tick (sockets should be me in this.sockets array)
         process.nextTick(() => {

--- a/build/test/api.flux-test.js
+++ b/build/test/api.flux-test.js
@@ -50,6 +50,15 @@ const src_1 = require("../src");
         console.log("Public IP %s Gateway IP %s", ip, gw.address);
         return net_1.default.isIP(ip) !== 0;
     }));
+    opts.run("Cache gateway and run without SSDP", () => __awaiter(void 0, void 0, void 0, function* () {
+        const gwInfo = yield client.getGateway();
+        console.log(`Gateway URL is: ${gwInfo.gateway.description}`);
+        console.log(`Gatway address is ${gwInfo.address}`);
+        const nonSsdpClient = new src_1.Client({ url: gwInfo.gateway.description });
+        const nonSsdpGwInfo = yield nonSsdpClient.getGateway();
+        console.log(`Non Ssdp Gateway address is ${nonSsdpGwInfo.address}`);
+        return nonSsdpGwInfo.address === gwInfo.address;
+    }));
     opts.run("Display Existing Port Mappings", () => __awaiter(void 0, void 0, void 0, function* () {
         const mappings = yield getMapping();
         if (mappings.length == 0)

--- a/build/test/api.flux-test.js
+++ b/build/test/api.flux-test.js
@@ -54,7 +54,7 @@ const src_1 = require("../src");
         const upnpInfo = yield client.getGateway();
         console.log(`Gateway URL is: ${upnpInfo.gateway.description}`);
         console.log(`Gatway address is ${upnpInfo.localAddress}`);
-        const nonSsdpClient = new src_1.Client({ url: upnpInfo.gateway.description });
+        const nonSsdpClient = new src_1.Client(upnpInfo);
         const nonSsdpupnpInfo = yield nonSsdpClient.getGateway();
         console.log(`Non Ssdp Gateway address is ${nonSsdpupnpInfo.localAddress}`);
         return nonSsdpupnpInfo.localAddress === upnpInfo.localAddress;

--- a/build/test/api.flux-test.js
+++ b/build/test/api.flux-test.js
@@ -47,17 +47,17 @@ const src_1 = require("../src");
     opts.run("Get public ip address", () => __awaiter(void 0, void 0, void 0, function* () {
         const ip = yield client.getPublicIp();
         const gw = yield client.getGateway();
-        console.log("Public IP %s Gateway IP %s", ip, gw.address);
+        console.log("Public IP %s Gateway IP %s", ip, gw.localAddress);
         return net_1.default.isIP(ip) !== 0;
     }));
     opts.run("Cache gateway and run without SSDP", () => __awaiter(void 0, void 0, void 0, function* () {
-        const gwInfo = yield client.getGateway();
-        console.log(`Gateway URL is: ${gwInfo.gateway.description}`);
-        console.log(`Gatway address is ${gwInfo.address}`);
-        const nonSsdpClient = new src_1.Client({ url: gwInfo.gateway.description });
-        const nonSsdpGwInfo = yield nonSsdpClient.getGateway();
-        console.log(`Non Ssdp Gateway address is ${nonSsdpGwInfo.address}`);
-        return nonSsdpGwInfo.address === gwInfo.address;
+        const upnpInfo = yield client.getGateway();
+        console.log(`Gateway URL is: ${upnpInfo.gateway.description}`);
+        console.log(`Gatway address is ${upnpInfo.localAddress}`);
+        const nonSsdpClient = new src_1.Client({ url: upnpInfo.gateway.description });
+        const nonSsdpupnpInfo = yield nonSsdpClient.getGateway();
+        console.log(`Non Ssdp Gateway address is ${nonSsdpupnpInfo.localAddress}`);
+        return nonSsdpupnpInfo.localAddress === upnpInfo.localAddress;
     }));
     opts.run("Display Existing Port Mappings", () => __awaiter(void 0, void 0, void 0, function* () {
         const mappings = yield getMapping();

--- a/build/test/index.flux-test.js
+++ b/build/test/index.flux-test.js
@@ -26,7 +26,7 @@ function runNextInQueue(prev) {
         footer(prev.length);
         const [name, opts] = (_a = queue.shift()) !== null && _a !== void 0 ? _a : [];
         if (!name || !opts)
-            return;
+            process.exit();
         header(name);
         opts.startTests().then(() => runNextInQueue(name));
     });

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@runonflux/nat-upnp",
-  "version": "1.1.0",
+  "name": "@megachips/nat-upnp",
+  "version": "1.1.1",
   "main": "build/src/index",
   "author": "Fedor Indutny <fedor@indutny.com>, SimplyLinn <https://github.com/SimplyLinn>, Kaden Sharpin <http://github.com/kaden-sharpin>",
-  "homepage": "https://github.com/runonflux/nat-upnp",
+  "homepage": "https://github.com/MorningLightMountain713/nat-upnp",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "http://github.com/runonflux/nat-upnp.git"
+    "url": "http://github.com/MorningLightMountain713/nat-upnp.git"
   },
   "scripts": {
     "build": "tsc",
@@ -21,11 +21,11 @@
     "flux"
   ],
   "devDependencies": {
-    "@types/node": "^17.0.21",
-    "typescript": "^4.5.5"
+    "@types/node": "^20.11.5",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
-    "axios": "^0.26.0",
-    "fast-xml-parser": "^4.0.3"
+    "axios": "^1.6.5",
+    "fast-xml-parser": "^4.3.3",
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "flux"
   ],
   "devDependencies": {
-    "@types/node": "^17.0.21",
-    "typescript": "^4.5.5"
+    "@types/node": "^20.10.7",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
-    "axios": "^0.26.0",
-    "fast-xml-parser": "^4.0.3"
+    "axios": "^1.6.5",
+    "fast-xml-parser": "^4.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "axios": "^1.6.5",
-    "fast-xml-parser": "^4.3.2"
+    "fast-xml-parser": "^4.3.2",
+    "npm": "^10.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "axios": "^1.6.5",
-    "fast-xml-parser": "^4.3.3",
+    "fast-xml-parser": "^4.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@megachips/nat-upnp",
   "version": "1.1.1",
   "main": "build/src/index",
+  "files": [
+    "/build"
+  ],
   "author": "Fedor Indutny <fedor@indutny.com>, SimplyLinn <https://github.com/SimplyLinn>, Kaden Sharpin <http://github.com/kaden-sharpin>",
   "homepage": "https://github.com/MorningLightMountain713/nat-upnp",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,11 @@
     "flux"
   ],
   "devDependencies": {
-    "@types/node": "^20.10.7",
-    "typescript": "^5.3.3"
+    "@types/node": "^17.0.21",
+    "typescript": "^4.5.5"
   },
   "dependencies": {
-    "axios": "^1.6.5",
-    "fast-xml-parser": "^4.3.2",
-    "npm": "^10.2.5"
+    "axios": "^0.26.0",
+    "fast-xml-parser": "^4.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runonflux/nat-upnp",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "build/src/index",
   "author": "Fedor Indutny <fedor@indutny.com>, SimplyLinn <https://github.com/SimplyLinn>, Kaden Sharpin <http://github.com/kaden-sharpin>",
   "homepage": "https://github.com/runonflux/nat-upnp",

--- a/src/nat-upnp/client.ts
+++ b/src/nat-upnp/client.ts
@@ -63,7 +63,7 @@ export class Client implements IClient {
       const data = (await gateway
         .run("GetGenericPortMappingEntry", [["NewPortMappingIndex", i++]])
         .catch((err) => {
-          if (i !== 1) {
+          if (i !== 1 || /ArrayIndexInvalid/.test(err?.response?.data)) {
             end = true;
           }
         }))!;

--- a/src/nat-upnp/client.ts
+++ b/src/nat-upnp/client.ts
@@ -244,6 +244,10 @@ export interface gatewayInfo {
  */
 export interface IClient {
   /**
+   * Allows bypass of SSDP in situations with multicast issues
+  */
+  url: string;
+  /**
    * Create a new port mapping
    * @param options Options for the new port mapping
    */

--- a/src/nat-upnp/client.ts
+++ b/src/nat-upnp/client.ts
@@ -246,7 +246,7 @@ export interface IClient {
   /**
    * Allows bypass of SSDP in situations with multicast issues
   */
-  url: string;
+  url: string | null;
   /**
    * Create a new port mapping
    * @param options Options for the new port mapping

--- a/src/nat-upnp/device.ts
+++ b/src/nat-upnp/device.ts
@@ -19,7 +19,7 @@ export class Device implements IDevice {
     return axios
       .get(url)
       .then(({ data }) => new XMLParser().parse(data))
-      .catch(() => new Error("Failed to lookup device description"));
+      .catch(() => { throw new Error("Router error. Failed to lookup device description") });
   }
   public async getService(types: string[]) {
     return this.getXML(this.description).then(({ root: xml }) => {

--- a/src/nat-upnp/ssdp.ts
+++ b/src/nat-upnp/ssdp.ts
@@ -33,12 +33,12 @@ export class Ssdp implements ISsdp {
       iface.family === "IPv4" ? "udp4" : "udp6"
     );
 
-    socket.on("message", (message) => {
+    socket.on("message", (message, remote) => {
       // Ignore messages after closing sockets
       if (this.closed) return;
 
       // Parse response
-      this.parseResponse(message.toString(), socket.address as any as string);
+      this.parseResponse(message.toString(), remote.address);
     });
 
     // Bind in next tick (sockets should be me in this.sockets array)

--- a/src/nat-upnp/ssdp.ts
+++ b/src/nat-upnp/ssdp.ts
@@ -133,8 +133,18 @@ export class Ssdp implements ISsdp {
   }
 
   public close() {
-    this.sockets.forEach((socket) => socket.close());
-    this.closed = true;
+    // idempotent
+    if (!this.closed) {
+      try {
+        this.sockets.forEach((socket) => socket.close());
+      } catch {
+        // pass
+      }
+      this.sockets.length = 0;
+      this.closed = true;
+      this.bound = false;
+      this.boundCount = 0;
+    }
   }
 }
 

--- a/src/nat-upnp/ssdp.ts
+++ b/src/nat-upnp/ssdp.ts
@@ -33,12 +33,12 @@ export class Ssdp implements ISsdp {
       iface.family === "IPv4" ? "udp4" : "udp6"
     );
 
-    socket.on("message", (message, remote) => {
+    socket.on("message", (message) => {
       // Ignore messages after closing sockets
       if (this.closed) return;
 
       // Parse response
-      this.parseResponse(message.toString(), remote.address);
+      this.parseResponse(message.toString(), socket.address().address);
     });
 
     // Bind in next tick (sockets should be me in this.sockets array)

--- a/src/nat-upnp/ssdp.ts
+++ b/src/nat-upnp/ssdp.ts
@@ -38,7 +38,7 @@ export class Ssdp implements ISsdp {
       if (this.closed) return;
 
       // Parse response
-      this.parseResponse(message.toString(), socket.address().address);
+      this.parseResponse(message.toString(), socket.address as any as string);
     });
 
     // Bind in next tick (sockets should be me in this.sockets array)

--- a/test/api.flux-test.ts
+++ b/test/api.flux-test.ts
@@ -35,19 +35,19 @@ setupTest("NAT-UPNP/Client", (opts) => {
   opts.run("Get public ip address", async () => {
     const ip = await client.getPublicIp();
     const gw = await client.getGateway();
-    console.log("Public IP %s Gateway IP %s", ip, gw.address);
+    console.log("Public IP %s Gateway IP %s", ip, gw.localAddress);
     return net.isIP(ip) !== 0;
   });
 
   opts.run("Cache gateway and run without SSDP", async () => {
-    const gwInfo = await client.getGateway();
-    console.log(`Gateway URL is: ${gwInfo.gateway.description}`)
-    console.log(`Gatway address is ${gwInfo.address}`);
+    const upnpInfo = await client.getGateway();
+    console.log(`Gateway URL is: ${upnpInfo.gateway.description}`)
+    console.log(`Gatway address is ${upnpInfo.localAddress}`);
 
-    const nonSsdpClient = new Client({url: gwInfo.gateway.description});
-    const nonSsdpGwInfo = await nonSsdpClient.getGateway();
-    console.log(`Non Ssdp Gateway address is ${nonSsdpGwInfo.address}`)
-    return nonSsdpGwInfo.address === gwInfo.address;
+    const nonSsdpClient = new Client({url: upnpInfo.gateway.description});
+    const nonSsdpupnpInfo = await nonSsdpClient.getGateway();
+    console.log(`Non Ssdp Gateway address is ${nonSsdpupnpInfo.localAddress}`)
+    return nonSsdpupnpInfo.localAddress === upnpInfo.localAddress;
   });
 
   opts.run("Display Existing Port Mappings", async () => {

--- a/test/api.flux-test.ts
+++ b/test/api.flux-test.ts
@@ -42,10 +42,11 @@ setupTest("NAT-UPNP/Client", (opts) => {
   opts.run("Cache gateway and run without SSDP", async () => {
     const gwInfo = await client.getGateway();
     console.log(`Gateway URL is: ${gwInfo.gateway.description}`)
+    console.log(`Gatway address is ${gwInfo.address}`);
 
     const nonSsdpClient = new Client({url: gwInfo.gateway.description});
     const nonSsdpGwInfo = await nonSsdpClient.getGateway();
-    nonSsdpClient.close();
+    console.log(`Non Ssdp Gateway address is ${nonSsdpGwInfo.address}`)
     return nonSsdpGwInfo.address === gwInfo.address;
   });
 

--- a/test/api.flux-test.ts
+++ b/test/api.flux-test.ts
@@ -44,7 +44,7 @@ setupTest("NAT-UPNP/Client", (opts) => {
     console.log(`Gateway URL is: ${upnpInfo.gateway.description}`)
     console.log(`Gatway address is ${upnpInfo.localAddress}`);
 
-    const nonSsdpClient = new Client({url: upnpInfo.gateway.description});
+    const nonSsdpClient = new Client(upnpInfo);
     const nonSsdpupnpInfo = await nonSsdpClient.getGateway();
     console.log(`Non Ssdp Gateway address is ${nonSsdpupnpInfo.localAddress}`)
     return nonSsdpupnpInfo.localAddress === upnpInfo.localAddress;

--- a/test/index.flux-test.ts
+++ b/test/index.flux-test.ts
@@ -15,7 +15,7 @@ async function runNextInQueue(prev: string) {
   footer(prev.length);
 
   const [name, opts] = queue.shift() ?? [];
-  if (!name || !opts) return;
+  if (!name || !opts) process.exit();
   header(name);
   opts.startTests().then(() => runNextInQueue(name));
 }


### PR DESCRIPTION
This pull is a precursor to larger work I'm doing that introduces a new package `fluxport-controller` that I'm hoping the main flux repo starts using. (I'll do a pull for that later)

Fluxport-controller uses multicast and the local nodes elect what port they want. It also factors in previous ports used etc. Means users don't have to configure ports anymore. I'll give more details when I push it to github. (for the flux team to fork and create npm package) It would also be opt in so users just set a new flag for it to operate. I just need to work with someone as Fluxbench will need to be updated to get the api port dynamically (I have about 6 different ways we could do this) Could do it without updating as well by just writing to the config file and restartnodebenchmarks rpc, but that's ugly.

**Background for this pull**

Flux leans heavily on UPnP, which in turn leans heavily on multicast. Multicast can be tricky - especially for home operators that like to tinker with a bunch of switches are routers in their environment, this can interfeer with multlicast operations.

A common issue is that a node will start up and upnp will work for the first 5 (or so) minutes, then igmp snooping kicks in and breaks the node. **This is because multicast is broken, not the actual UPnP router service.**

**Interop with existing fluxOS**

This pull doesn't change any of the existing functionality. It's only when extra parameters are passed in do things behave differently. 

**Testing**

All tests passing. Can be run with `npm run flux-test`. If required, I can provide a `docker-compose` file that includes an isolated network and miniupnpd implementation, that will auto-run the tests.

**New features**

* gateway caching

This is a flag that can be turned on in the `Client` i.e `new Client({ cacheGateway: true });`. What this does: On each call to `getGateway()` the client will cache the SSDP (multicast) respose that gives the url for the upnp service on the router. If multicast then breaks and the SSDP call times out, it will return the cached SSDP info.

* non SSDP (multicast) client

This gives the ability to be able to pass in the UPnP service router url and the local address (the target of the port forwards) so that SSDP can be bypassed entirely. This is sort of the same as gateway caching but is meant for users to be able to pass in - in a secenario where SSDP is broken, this is faster as the promise returns immediately, instead of waiting for the timeout.

**New tests** 

* Added test for a cached gateway returning the same info as non cached gateway.
* Added larger test that uses iptables to simulate a broken SSDP implementation and test a cached gateway, default gateway, and no SSDP gateway.

**Commits worth noting**

e537bb9 - This was returning an error that wasn't being handled properly by the upper layer, now just throws.

6ed8841 - There are better ways to implement `getMappings` but they involve double parsing and changing the types as the api calls return different objects, so I left this. However,  I did fix an error here where if there are no mappings, it was returning an error - which is incorrect. Specifically for `miniupnpd` it will return an index error. We now test for this and return empty array if that's the case. If other implementations return something different, then it will revert to the prior behavior.

6763ca0 - I was wrong here. I thought the address was the remote address, but it's the local address used for a mapping target. Fixed this up in a subsequent commit and changed the variable name to better reflect the intent.

3a14b07 - This is the meat of the tests. 

d8a1913 - Initially, I bumped all the deps to the latest versions. Tested and all working. However, wasn't sure how this would interop with fluxOS, so reverted.











